### PR TITLE
Fixes usage of Tab Key in QWinWidget

### DIFF
--- a/qtwinmigrate/src/qwinwidget.cpp
+++ b/qtwinmigrate/src/qwinwidget.cpp
@@ -125,9 +125,9 @@ void QWinWidget::init()
     if (hParent) {
 	// make the widget window style be WS_CHILD so SetParent will work
 	QT_WA({
-        SetWindowLong((HWND)winId(), GWL_STYLE, WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS);
+		SetWindowLong((HWND) winId(), GWL_STYLE, WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_TABSTOP);
 	}, {
-        SetWindowLongA((HWND)winId(), GWL_STYLE, WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS);
+		SetWindowLongA((HWND) winId(), GWL_STYLE, WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_TABSTOP);
 	})
 #if QT_VERSION >= 0x050000
         QWindow *window = windowHandle();
@@ -251,9 +251,9 @@ void QWinWidget::resetFocus()
 /*! \reimp
 */
 #if QT_VERSION >= 0x050000
-bool QWinWidget::nativeEvent(const QByteArray &, void *message, long *)
+bool QWinWidget::nativeEvent(const QByteArray &, void *message, long *result)
 #else
-bool QWinWidget::winEvent(MSG *msg, long *)
+bool QWinWidget::winEvent(MSG *msg, long *result)
 #endif
 {
 #if QT_VERSION >= 0x050000
@@ -270,6 +270,10 @@ bool QWinWidget::winEvent(MSG *msg, long *)
         QFocusEvent e(QEvent::FocusIn, reason);
         QApplication::sendEvent(this, &e);
     }
+	else if (msg->message == WM_GETDLGCODE) {
+		*result = DLGC_WANTARROWS | DLGC_WANTTAB;
+		return true;
+	}
 
     return false;
 }


### PR DESCRIPTION
Tab Key does not work in QWinWidget in some situations
This commit fixes the problem using the code suggested by Andrew
Garrison in the following StackOverflow question:
http://stackoverflow.com/questions/1066183/qwinwidget-inside-mfc-dialog-not-repainting-or-responding-to-tab-arrow-keys