### PR TITLE
QtService: Add handlerEx callback to Windows Services

### DIFF
--- a/qtservice/src/qhandleexevent.h
+++ b/qtservice/src/qhandleexevent.h
@@ -1,0 +1,50 @@
+#ifndef QHANDLEEXEVENT_H
+#define QHANDLEEXEVENT_H
+
+#include <QEvent>
+
+class QHandleExEvent : public QEvent
+{
+public:
+    QHandleExEvent(QEvent::Type type, DWORD dwEventType, LPVOID lpEventData,  LPVOID lpContext ) : QEvent(type)
+    {
+        m_type = type;
+        m_dwEventType = dwEventType;
+        m_lpEventData = lpEventData;
+        m_lpContext = lpContext;
+    }
+
+    ~QHandleExEvent()
+    {
+
+    }
+
+    QEvent::Type type()
+    {
+        return m_type;
+    }
+
+    DWORD dwEventType()
+    {
+        return m_dwEventType;
+    }
+
+    LPVOID lpEventData()
+    {
+        return m_lpEventData;
+    }
+
+    LPVOID lpContext()
+    {
+        return m_lpContext;
+    }
+
+private:
+    QEvent::Type m_type;
+    DWORD m_dwEventType;
+    LPVOID m_lpEventData;
+    LPVOID m_lpContext;
+
+};
+
+#endif // QHANDLEEXEVENT_H

--- a/qtservice/src/qtservice.cpp
+++ b/qtservice/src/qtservice.cpp
@@ -892,6 +892,11 @@ QtServiceBase *QtServiceBase::instance()
     return QtServiceBasePrivate::instance;
 }
 
+QString QtServiceBase::filePath()
+{
+    return d_ptr->filePath();
+}
+
 /*!
     \fn void QtServiceBase::start()
 
@@ -947,6 +952,11 @@ void QtServiceBase::pause()
 */
 void QtServiceBase::resume()
 {
+}
+
+void QtServiceBase::processExEvent(QEvent *e)
+{
+    Q_UNUSED(e)
 }
 
 /*!

--- a/qtservice/src/qtservice.h
+++ b/qtservice/src/qtservice.h
@@ -68,7 +68,7 @@ class QT_QTSERVICE_EXPORT QtServiceController
 public:
     enum StartupType
     {
-	    AutoStartup = 0, ManualStartup
+        AutoStartup = 0, ManualStartup
     };
 
     QtServiceController(const QString &name);
@@ -83,7 +83,7 @@ public:
     QString serviceFilePath() const;
 
     static bool install(const QString &serviceFilePath, const QString &account = QString(),
-                const QString &password = QString());
+                        const QString &password = QString());
     bool uninstall();
 
     bool start(const QStringList &arguments);
@@ -106,7 +106,7 @@ public:
 
     enum MessageType
     {
-	Success = 0, Error, Warning, Information
+        Success = 0, Error, Warning, Information
     };
 
     enum ServiceFlag
@@ -136,9 +136,11 @@ public:
     int exec();
 
     void logMessage(const QString &message, MessageType type = Success,
-                int id = 0, uint category = 0, const QByteArray &data = QByteArray());
+                    int id = 0, uint category = 0, const QByteArray &data = QByteArray());
 
     static QtServiceBase *instance();
+
+    QString filePath();
 
 protected:
 
@@ -146,6 +148,7 @@ protected:
     virtual void stop();
     virtual void pause();
     virtual void resume();
+    virtual void processExEvent(QEvent *e);
     virtual void processCommand(int code);
 
     virtual void createApplication(int &argc, char **argv) = 0;

--- a/qtservice/src/qtservice.pri
+++ b/qtservice/src/qtservice.pri
@@ -10,6 +10,7 @@ qtservice-uselib:!qtservice-buildlib {
     HEADERS       += $$PWD/qtservice.h \
                      $$PWD/qtservice_p.h
     SOURCES       += $$PWD/qtservice.cpp
+    win32:HEADERS += $$PWD/qhandleexevent.h
     win32:SOURCES += $$PWD/qtservice_win.cpp
     unix:HEADERS  += $$PWD/qtunixsocket.h $$PWD/qtunixserversocket.h
     unix:SOURCES  += $$PWD/qtservice_unix.cpp $$PWD/qtunixsocket.cpp $$PWD/qtunixserversocket.cpp

--- a/qtservice/src/qtservice_win.cpp
+++ b/qtservice/src/qtservice_win.cpp
@@ -64,6 +64,8 @@
 
 typedef SERVICE_STATUS_HANDLE(WINAPI*PRegisterServiceCtrlHandler)(const wchar_t*,LPHANDLER_FUNCTION);
 static PRegisterServiceCtrlHandler pRegisterServiceCtrlHandler = 0;
+typedef SERVICE_STATUS_HANDLE(WINAPI*PRegisterServiceCtrlHandlerEx)(LPCTSTR,LPHANDLER_FUNCTION_EX,LPVOID);
+static PRegisterServiceCtrlHandlerEx pRegisterServiceCtrlHandlerEx = 0;
 typedef BOOL(WINAPI*PSetServiceStatus)(SERVICE_STATUS_HANDLE,LPSERVICE_STATUS);
 static PSetServiceStatus pSetServiceStatus = 0;
 typedef BOOL(WINAPI*PChangeServiceConfig2)(SC_HANDLE,DWORD,LPVOID);
@@ -111,6 +113,7 @@ static bool winServiceInit()
 
         // only resolve unicode versions
         RESOLVEW(RegisterServiceCtrlHandler);
+        RESOLVEW(RegisterServiceCtrlHandlerEx);
         RESOLVE(SetServiceStatus);
         RESOLVEW(ChangeServiceConfig2);
         RESOLVE(CloseServiceHandle);
@@ -219,16 +222,16 @@ QString QtServiceController::serviceDescription() const
     if (hSCM) {
         // Try to open the service
         SC_HANDLE hService = pOpenService(hSCM, (wchar_t *)d->serviceName.utf16(),
-             SERVICE_QUERY_CONFIG);
+                                          SERVICE_QUERY_CONFIG);
         if (hService) {
             DWORD dwBytesNeeded;
             char data[8 * 1024];
             if (pQueryServiceConfig2(
-                    hService,
-                    SERVICE_CONFIG_DESCRIPTION,
-                    (unsigned char *)data,
-                    8096,
-                    &dwBytesNeeded)) {
+                        hService,
+                        SERVICE_CONFIG_DESCRIPTION,
+                        (unsigned char *)data,
+                        8096,
+                        &dwBytesNeeded)) {
                 LPSERVICE_DESCRIPTION desc = (LPSERVICE_DESCRIPTION)data;
                 if (desc->lpDescription)
                     result = QString::fromUtf16((const ushort*)desc->lpDescription);
@@ -358,7 +361,7 @@ bool QtServiceController::pause()
     SC_HANDLE hSCM = pOpenSCManager(0, 0, SC_MANAGER_CONNECT);
     if (hSCM) {
         SC_HANDLE hService = pOpenService(hSCM, (wchar_t *)d->serviceName.utf16(),
-                             SERVICE_PAUSE_CONTINUE);
+                                          SERVICE_PAUSE_CONTINUE);
         if (hService) {
             SERVICE_STATUS status;
             if (pControlService(hService, SERVICE_CONTROL_PAUSE, &status))
@@ -380,7 +383,7 @@ bool QtServiceController::resume()
     SC_HANDLE hSCM = pOpenSCManager(0, 0, SC_MANAGER_CONNECT);
     if (hSCM) {
         SC_HANDLE hService = pOpenService(hSCM, (wchar_t *)d->serviceName.utf16(),
-                             SERVICE_PAUSE_CONTINUE);
+                                          SERVICE_PAUSE_CONTINUE);
         if (hService) {
             SERVICE_STATUS status;
             if (pControlService(hService, SERVICE_CONTROL_CONTINUE, &status))
@@ -394,9 +397,9 @@ bool QtServiceController::resume()
 
 bool QtServiceController::sendCommand(int code)
 {
-   Q_D(QtServiceController);
-   bool result = false;
-   if (!winServiceInit())
+    Q_D(QtServiceController);
+    bool result = false;
+    if (!winServiceInit())
         return result;
 
     if (code < 0 || code > 127 || !isRunning())
@@ -426,7 +429,7 @@ extern void qtServiceLogDebug(QtMsgType type, const char* msg);
 #endif
 
 void QtServiceBase::logMessage(const QString &message, MessageType type,
-                           int id, uint category, const QByteArray &data)
+                               int id, uint category, const QByteArray &data)
 {
 #if defined(QTSERVICE_DEBUG)
     QByteArray dbgMsg("[LOGGED ");
@@ -491,9 +494,11 @@ public:
     inline bool available() const;
     static void WINAPI serviceMain( DWORD dwArgc, wchar_t** lpszArgv );
     static void WINAPI handler( DWORD dwOpcode );
+    static DWORD WINAPI handlerEx( DWORD dwOpcode, DWORD dwEventType, LPVOID lpEventData,  LPVOID lpContext );
 
     SERVICE_STATUS status;
     SERVICE_STATUS_HANDLE serviceStatus;
+    bool useHandlerEx;
     QStringList serviceArgs;
 
     static QtServiceSysPrivate *instance;
@@ -552,14 +557,30 @@ void WINAPI QtServiceSysPrivate::serviceMain(DWORD dwArgc, wchar_t** lpszArgv)
 
     instance->startSemaphore.release(); // let the qapp creation start
     instance->startSemaphore2.acquire(); // wait until its done
+
     // Register the control request handler
-    instance->serviceStatus = pRegisterServiceCtrlHandler((TCHAR*)QtServiceBase::instance()->serviceName().utf16(), handler);
+    if(pRegisterServiceCtrlHandlerEx)
+    {
+        instance->useHandlerEx = true;
+        instance->serviceStatus = pRegisterServiceCtrlHandlerEx((TCHAR*)QtServiceBase::instance()->serviceName().utf16(), handlerEx, NULL);
 
-    if (!instance->serviceStatus) // cannot happen - something is utterly wrong
-        return;
+        if (!instance->serviceStatus) // cannot happen - something is utterly wrong
+            return;
 
-    handler(QTSERVICE_STARTUP); // Signal startup to the application -
-                                // causes QtServiceBase::start() to be called in the main thread
+        handlerEx(QTSERVICE_STARTUP, NULL, NULL, NULL); // Signal startup to the application -
+        // causes QtServiceBase::start() to be called in the main thread
+    }
+    else
+    {
+        instance->useHandlerEx = false;
+        instance->serviceStatus = pRegisterServiceCtrlHandler((TCHAR*)QtServiceBase::instance()->serviceName().utf16(), handler);
+
+        if (!instance->serviceStatus) // cannot happen - something is utterly wrong
+            return;
+
+        handler(QTSERVICE_STARTUP); // Signal startup to the application -
+        // causes QtServiceBase::start() to be called in the main thread
+    }
 
     // The MSDN doc says that this thread should just exit - the service is
     // running in the main thread (here, via callbacks in the handler thread).
@@ -590,8 +611,8 @@ void QtServiceSysPrivate::handleCustomEvent(QEvent *e)
         QtServiceBase::instance()->resume();
         break;
     default:
-	if (code >= 128 && code <= 255)
-	    QtServiceBase::instance()->processCommand(code - 128);
+        if (code >= 128 && code <= 255)
+            QtServiceBase::instance()->processCommand(code - 128);
         break;
     }
 
@@ -659,10 +680,83 @@ void WINAPI QtServiceSysPrivate::handler( DWORD code )
         pSetServiceStatus(instance->serviceStatus, &instance->status);
 }
 
+DWORD WINAPI QtServiceSysPrivate::handlerEx( DWORD code, DWORD dwEventType, LPVOID lpEventData,  LPVOID lpContext )
+{
+    DWORD dwRet = NO_ERROR;
+
+    if (!instance)
+        return dwRet;
+
+    instance->mutex.lock();
+    switch (code) {
+    case QTSERVICE_STARTUP: // QtService startup (called from WinMain when started)
+        instance->setStatus(SERVICE_START_PENDING);
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + code)));
+        instance->condition.wait(&instance->mutex);
+        instance->setStatus(SERVICE_RUNNING);
+        break;
+    case SERVICE_CONTROL_STOP: // 1
+        instance->setStatus(SERVICE_STOP_PENDING);
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + code)));
+        instance->condition.wait(&instance->mutex);
+        // status will be reported as stopped by start() when qapp::exec returns
+        break;
+
+    case SERVICE_CONTROL_PAUSE: // 2
+        instance->setStatus(SERVICE_PAUSE_PENDING);
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + code)));
+        instance->condition.wait(&instance->mutex);
+        instance->setStatus(SERVICE_PAUSED);
+        break;
+
+    case SERVICE_CONTROL_CONTINUE: // 3
+        instance->setStatus(SERVICE_CONTINUE_PENDING);
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + code)));
+        instance->condition.wait(&instance->mutex);
+        instance->setStatus(SERVICE_RUNNING);
+        break;
+
+    case SERVICE_CONTROL_INTERROGATE: // 4
+        break;
+
+    case SERVICE_CONTROL_SHUTDOWN: // 5
+        // Don't waste time with reporting stop pending, just do it
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + SERVICE_CONTROL_STOP)));
+        instance->condition.wait(&instance->mutex);
+        // status will be reported as stopped by start() when qapp::exec returns
+        break;
+
+    case SERVICE_CONTROL_POWEREVENT:
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + SERVICE_CONTROL_POWEREVENT)));
+        instance->condition.wait(&instance->mutex);
+        break;
+
+    case SERVICE_CONTROL_SESSIONCHANGE:
+        QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + SERVICE_CONTROL_SESSIONCHANGE)));
+        instance->condition.wait(&instance->mutex);
+        break;
+
+    default:
+        if ( code >= 128 && code <= 255 ) {
+            QCoreApplication::postEvent(instance->controllerHandler, new QEvent(QEvent::Type(QEvent::User + code)));
+            instance->condition.wait(&instance->mutex);
+        }
+        break;
+    }
+
+    instance->mutex.unlock();
+
+    // Report current status
+    if (instance->available() && instance->status.dwCurrentState != SERVICE_STOPPED)
+        pSetServiceStatus(instance->serviceStatus, &instance->status);
+
+    return dwRet;
+}
+
 void QtServiceSysPrivate::setStatus(DWORD state)
 {
     if (!available())
-	return;
+        return;
     status.dwCurrentState = state;
     pSetServiceStatus(serviceStatus, &status);
 }
@@ -696,7 +790,7 @@ class HandlerThread : public QThread
 public:
     HandlerThread()
         : success(true), console(false), QThread()
-        {}
+    {}
 
     bool calledOk() { return success; }
     bool runningAsConsole() { return console; }
@@ -704,27 +798,27 @@ public:
 protected:
     bool success, console;
     void run()
-        {
-            SERVICE_TABLE_ENTRYW st [2];
-            st[0].lpServiceName = (wchar_t*)QtServiceBase::instance()->serviceName().utf16();
-            st[0].lpServiceProc = QtServiceSysPrivate::serviceMain;
-            st[1].lpServiceName = 0;
-            st[1].lpServiceProc = 0;
+    {
+        SERVICE_TABLE_ENTRYW st [2];
+        st[0].lpServiceName = (wchar_t*)QtServiceBase::instance()->serviceName().utf16();
+        st[0].lpServiceProc = QtServiceSysPrivate::serviceMain;
+        st[1].lpServiceName = 0;
+        st[1].lpServiceProc = 0;
 
-            success = (pStartServiceCtrlDispatcher(st) != 0); // should block
+        success = (pStartServiceCtrlDispatcher(st) != 0); // should block
 
-            if (!success) {
-                if (GetLastError() == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
-                    // Means we're started from console, not from service mgr
-                    // start() will ask the mgr to start another instance of us as a service instead
-                    console = true;
-                }
-                else {
-                    QtServiceBase::instance()->logMessage(QString("The Service failed to start [%1]").arg(qt_error_string(GetLastError())), QtServiceBase::Error);
-                }
-                QtServiceSysPrivate::instance->startSemaphore.release();  // let start() continue, since serviceMain won't be doing it
+        if (!success) {
+            if (GetLastError() == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
+                // Means we're started from console, not from service mgr
+                // start() will ask the mgr to start another instance of us as a service instead
+                console = true;
             }
+            else {
+                QtServiceBase::instance()->logMessage(QString("The Service failed to start [%1]").arg(qt_error_string(GetLastError())), QtServiceBase::Error);
+            }
+            QtServiceSysPrivate::instance->startSemaphore.release();  // let start() continue, since serviceMain won't be doing it
         }
+    }
 };
 
 /*
@@ -919,6 +1013,11 @@ bool QtServiceBasePrivate::sysInit()
     sysd->status.dwServiceType		    = SERVICE_WIN32_OWN_PROCESS|SERVICE_INTERACTIVE_PROCESS;
     sysd->status.dwCurrentState		    = SERVICE_STOPPED;
     sysd->status.dwControlsAccepted         = sysd->serviceFlags(serviceFlags);
+    if(sysd->useHandlerEx)
+    {
+        sysd->status.dwControlsAccepted |= SERVICE_ACCEPT_POWEREVENT;
+        sysd->status.dwControlsAccepted |= SERVICE_ACCEPT_SESSIONCHANGE;
+    }
     sysd->status.dwWin32ExitCode	    = NO_ERROR;
     sysd->status.dwServiceSpecificExitCode  = 0;
     sysd->status.dwCheckPoint		    = 0;


### PR DESCRIPTION
An application-defined callback function used with the RegisterServiceCtrlHandlerEx function.

Need to receive more events, e.g. SERVICE_CONTROL_SESSIONCHANGE

Read more: https://msdn.microsoft.com/en-us/library/ms683241(VS.85).aspx