### PR TITLE
incomingConnection(int) 64-bit compile issue

### DIFF
--- a/qtservice/examples/server/main.cpp
+++ b/qtservice/examples/server/main.cpp
@@ -60,7 +60,7 @@ public:
         listen(QHostAddress::Any, port);
     }
 
-    void incomingConnection(int socket)
+    void incomingConnection(qintptr socket)
     {
         if (disabled)
             return;


### PR DESCRIPTION
It doesn't overwrite QTcpServer::incomingConnection(**qintptr** socketDescriptor) when I compile the example with Qt 5.8 using VS 2015 targeting for 64-bit Windows system. Solved when I change "**int**" to "**qintptr**", which makes good sense to me since it is typedefed as "**qint64**" for x64 and as "**qint32**" for Win32.