### PR TITLE
Fixing comparison between two different enums

### DIFF
--- a/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/qtsingleapplication/src/qtlocalpeer.cpp
@@ -177,7 +177,7 @@ void QtLocalPeer::receiveConnection()
         return;
 
     while (true) {
-        if (socket->state() == QAbstractSocket::UnconnectedState) {
+        if (socket->state() == QLocalSocket::UnconnectedState) {
             qWarning("QtLocalPeer: Peer disconnected");
             delete socket;
             return;


### PR DESCRIPTION
Currently there's a comparison between `QLocalSocket::LocalSocketState` and `QAbstractSocket::SocketState` which also throws a compiler warning. This is a fix for that.