### PR TITLE
QtPropertyBrowser: resizeToContent(), bold property text, read-only handling

### DIFF
--- a/qtpropertybrowser/src/qtpropertybrowser.cpp
+++ b/qtpropertybrowser/src/qtpropertybrowser.cpp
@@ -59,6 +59,7 @@ public:
     QtPropertyPrivate(QtAbstractPropertyManager *manager)
         : m_enabled(true),
           m_modified(false),
+          m_bold(false),
           m_manager(manager) {}
     QtProperty *q_ptr;
 
@@ -71,6 +72,7 @@ public:
     QString m_name;
     bool m_enabled;
     bool m_modified;
+    bool m_bold;
 
     QtAbstractPropertyManager * const m_manager;
 };
@@ -265,6 +267,16 @@ bool QtProperty::isModified() const
 }
 
 /*!
+    Returns whether the property is bold.
+
+    \sa setBold()
+*/
+bool QtProperty::isBold() const
+{
+    return d_ptr->m_bold;
+}
+
+/*!
     Returns whether the property has a value.
 
     \sa QtAbstractPropertyManager::hasValue()
@@ -396,6 +408,20 @@ void QtProperty::setModified(bool modified)
         return;
 
     d_ptr->m_modified = modified;
+    propertyChanged();
+}
+
+/*!
+    Sets the property's bold state according to the passed \a bold value.
+
+    \sa isBold()
+*/
+void QtProperty::setBold(bool bold)
+{
+    if (d_ptr->m_bold == bold)
+        return;
+
+    d_ptr->m_bold = bold;
     propertyChanged();
 }
 

--- a/qtpropertybrowser/src/qtpropertybrowser.h
+++ b/qtpropertybrowser/src/qtpropertybrowser.h
@@ -86,6 +86,7 @@ public:
     QString propertyName() const;
     bool isEnabled() const;
     bool isModified() const;
+    bool isBold() const;
 
     bool hasValue() const;
     QIcon valueIcon() const;
@@ -98,6 +99,7 @@ public:
     void setPropertyName(const QString &text);
     void setEnabled(bool enable);
     void setModified(bool modified);
+    void setBold(bool bold);
 
     void addSubProperty(QtProperty *property);
     void insertSubProperty(QtProperty *property, QtProperty *afterProperty);

--- a/qtpropertybrowser/src/qtpropertymanager.cpp
+++ b/qtpropertybrowser/src/qtpropertymanager.cpp
@@ -508,7 +508,7 @@ QtMetaEnumProvider::QtMetaEnumProvider()
                 QtMetaEnumWrapper::staticMetaObject.propertyOffset() + 0);
     m_policyEnum = p.enumerator();
     const int keyCount = m_policyEnum.keyCount();
-    for (int i = 0; i < keyCount; i++)
+    for (int i = 0; i < keyCount; ++i)
         m_policyEnumNames << QLatin1String(m_policyEnum.key(i));
 
     initLocale();
@@ -522,7 +522,7 @@ QSizePolicy::Policy QtMetaEnumProvider::indexToSizePolicy(int index) const
 int QtMetaEnumProvider::sizePolicyToIndex(QSizePolicy::Policy policy) const
 {
      const int keyCount = m_policyEnum.keyCount();
-    for (int i = 0; i < keyCount; i++)
+    for (int i = 0; i < keyCount; ++i)
         if (indexToSizePolicy(i) == policy)
             return i;
     return -1;
@@ -891,7 +891,7 @@ void QtIntPropertyManager::setSingleStep(QtProperty *property, int step)
 /*!
     Sets read-only status of the property.
 
-    \sa QtIntPropertyManager::setReadOnly
+    \sa QtIntPropertyManager::isReadOnly
 */
 void QtIntPropertyManager::setReadOnly(QtProperty *property, bool readOnly)
 {
@@ -1165,7 +1165,7 @@ void QtDoublePropertyManager::setSingleStep(QtProperty *property, double step)
 /*!
     Sets read-only status of the property.
 
-    \sa QtDoublePropertyManager::setReadOnly
+    \sa QtDoublePropertyManager::isReadOnly
 */
 void QtDoublePropertyManager::setReadOnly(QtProperty *property, bool readOnly)
 {
@@ -1526,7 +1526,7 @@ void QtStringPropertyManager::setEchoMode(QtProperty *property, EchoMode echoMod
 /*!
     Sets read-only status of the property.
 
-    \sa QtStringPropertyManager::setReadOnly
+    \sa QtStringPropertyManager::isReadOnly
 */
 void QtStringPropertyManager::setReadOnly(QtProperty *property, bool readOnly)
 {
@@ -1543,7 +1543,7 @@ void QtStringPropertyManager::setReadOnly(QtProperty *property, bool readOnly)
     it.value() = data;
 
     emit propertyChanged(property);
-    emit readOnlyChanged(property, data.readOnly);
+    emit readOnlyChanged(property, data.echoMode);
 }
 
 /*!
@@ -4821,6 +4821,7 @@ public:
     {
         Data() : val(-1) {}
         int val;
+        bool readOnly;
         QStringList enumNames;
         QMap<int, QIcon> enumIcons;
     };
@@ -5060,6 +5061,41 @@ void QtEnumPropertyManager::setEnumIcons(QtProperty *property, const QMap<int, Q
     emit enumIconsChanged(property, it.value().enumIcons);
 
     emit propertyChanged(property);
+}
+
+/*!
+    Returns read-only status of the property.
+
+    When property is read-only it's value can be selected and copied from editor but not modified.
+
+    \sa QtEnumPropertyManager::setReadOnly
+*/
+bool QtEnumPropertyManager::isReadOnly(const QtProperty *property) const
+{
+    return getData<bool>(d_ptr->m_values, &QtEnumPropertyManagerPrivate::Data::readOnly, property, false);
+}
+
+/*!
+    Sets read-only status of the property.
+
+    \sa QtEnumPropertyManager::isReadOnly
+*/
+void QtEnumPropertyManager::setReadOnly(QtProperty *property, bool readOnly)
+{
+    const QtEnumPropertyManagerPrivate::PropertyValueMap::iterator it = d_ptr->m_values.find(property);
+    if (it == d_ptr->m_values.end())
+        return;
+
+    QtEnumPropertyManagerPrivate::Data data = it.value();
+
+    if (data.readOnly == readOnly)
+        return;
+
+    data.readOnly = readOnly;
+    it.value() = data;
+
+    emit propertyChanged(property);
+    emit readOnlyChanged(property, data.readOnly);
 }
 
 /*!

--- a/qtpropertybrowser/src/qtpropertymanager.h
+++ b/qtpropertybrowser/src/qtpropertymanager.h
@@ -198,7 +198,7 @@ Q_SIGNALS:
     void valueChanged(QtProperty *property, const QString &val);
     void regExpChanged(QtProperty *property, const QRegExp &regExp);
     void echoModeChanged(QtProperty *property, const int);
-    void readOnlyChanged(QtProperty *property, bool);
+    void readOnlyChanged(QtProperty *property, bool readOnly);
 
 protected:
     QString valueText(const QtProperty *property) const;
@@ -585,15 +585,18 @@ public:
     int value(const QtProperty *property) const;
     QStringList enumNames(const QtProperty *property) const;
     QMap<int, QIcon> enumIcons(const QtProperty *property) const;
+    bool isReadOnly(const QtProperty *property) const;
 
 public Q_SLOTS:
     void setValue(QtProperty *property, int val);
     void setEnumNames(QtProperty *property, const QStringList &names);
     void setEnumIcons(QtProperty *property, const QMap<int, QIcon> &icons);
+    void setReadOnly(QtProperty *property, bool readOnly);
 Q_SIGNALS:
     void valueChanged(QtProperty *property, int val);
     void enumNamesChanged(QtProperty *property, const QStringList &names);
     void enumIconsChanged(QtProperty *property, const QMap<int, QIcon> &icons);
+    void readOnlyChanged(QtProperty *property, bool readOnly);
 protected:
     QString valueText(const QtProperty *property) const;
     QIcon valueIcon(const QtProperty *property) const;

--- a/qtpropertybrowser/src/qttreepropertybrowser.cpp
+++ b/qtpropertybrowser/src/qttreepropertybrowser.cpp
@@ -1071,6 +1071,17 @@ void QtTreePropertyBrowser::editItem(QtBrowserItem *item)
     d_ptr->editItem(item);
 }
 
+/*!
+Ensure that the column width fits the current content size. Useful to ensure that
+as much as possible is visible for the user based on the current content, while still
+allowing for the overall resize mode to be QHeaderView::Interactive for the
+user to adjust individually as needed.
+*/
+void QtTreePropertyBrowser::resizeToContent() const
+{
+    d_ptr->m_treeWidget->header()->resizeSections(QHeaderView::ResizeToContents);
+}
+
 #if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
 #endif

--- a/qtpropertybrowser/src/qttreepropertybrowser.h
+++ b/qtpropertybrowser/src/qttreepropertybrowser.h
@@ -108,6 +108,8 @@ public:
 
     void editItem(QtBrowserItem *item);
 
+    void resizeToContent() const;
+
 Q_SIGNALS:
 
     void collapsed(QtBrowserItem *item);


### PR DESCRIPTION
- New method resizeToContet() to allow resizing to display as much content as possible to the user, while still having the option to set the overall resize mode to e.g. "QHeaderView::Interactive".
- Read-only functionality for enum property manager
- Bold text option for property
