### PR TITLE
Added support systemd for qt-service

### DIFF
--- a/qtservice/src/qtservice.h
+++ b/qtservice/src/qtservice.h
@@ -94,6 +94,9 @@ public:
     bool sendCommand(int code);
 
 private:
+    bool uninstallSysD(const QString &serviceName);
+    bool uninstallUpStart();
+
     QtServiceControllerPrivate *d_ptr;
 };
 
@@ -132,6 +135,7 @@ public:
 
     ServiceFlags serviceFlags() const;
     void setServiceFlags(ServiceFlags flags);
+    void setServiceExecutable(const QString& exec);
 
     int exec();
 

--- a/qtservice/src/qtservice_p.h
+++ b/qtservice/src/qtservice_p.h
@@ -63,7 +63,7 @@ public:
     QtServiceBase *q_ptr;
 
     QString serviceDescription;
-    QString serviceCustomPass;
+    QString serviceCustomPath;
 
     QtServiceController::StartupType startupType;
     QtServiceBase::ServiceFlags serviceFlags;

--- a/qtservice/src/qtservice_p.h
+++ b/qtservice/src/qtservice_p.h
@@ -63,6 +63,8 @@ public:
     QtServiceBase *q_ptr;
 
     QString serviceDescription;
+    QString serviceCustomPass;
+
     QtServiceController::StartupType startupType;
     QtServiceBase::ServiceFlags serviceFlags;
     QStringList args;
@@ -74,7 +76,8 @@ public:
     void startService();
     int run(bool asService, const QStringList &argList);
     bool install(const QString &account, const QString &password);
-
+    bool installSysD(const QString &account, const QString &password);
+    bool installUpStart(const QString &account, const QString &password);
     bool start();
 
     QString filePath() const;

--- a/qtservice/src/qtservice_unix.cpp
+++ b/qtservice/src/qtservice_unix.cpp
@@ -175,8 +175,8 @@ static QString absPath(const QString &path)
 
 QString QtServiceBasePrivate::filePath() const
 {
-    if (!serviceCustomPass.isEmpty())
-        return serviceCustomPass;
+    if (!serviceCustomPath.isEmpty())
+        return serviceCustomPath;
 
     QString ret;
     if (args.isEmpty())
@@ -595,5 +595,5 @@ void QtServiceBase::setServiceFlags(QtServiceBase::ServiceFlags flags)
 
 void QtServiceBase::setServiceExecutable(const QString &exec)
 {
-    d_ptr->serviceCustomPass= exec;
+    d_ptr->serviceCustomPath= exec;
 }

--- a/qtservice/src/qtservice_unix.cpp
+++ b/qtservice/src/qtservice_unix.cpp
@@ -64,10 +64,10 @@ static bool isServiceInited = false;
 
 static bool isSystemD()
 {
-    return QFileInfo::exists("/etc/systemd/");
+    return QFileInfo::exists(systemDPath());
 }
 
-static QString systemDPass()
+static QString systemDPath()
 {
     return "/etc/systemd/system/";
 }
@@ -79,7 +79,7 @@ static void initService()
     {
         QSettings::setPath(QSettings::NativeFormat,
                            QSettings::SystemScope,
-                           systemDPass());
+                           systemDPath());
         isServiceInited = true;
     }
 }
@@ -233,7 +233,7 @@ bool QtServiceController::uninstall()
 {
 
     if (isSystemD()) {
-        uninstallSysD(systemDPass() + serviceName() + ".service");
+        uninstallSysD(systemDPath() + serviceName() + ".service");
     }
 
     return uninstallUpStart();
@@ -298,7 +298,7 @@ bool QtServiceController::isInstalled() const
 {
 
     if (isSystemD()) {
-        return QFileInfo::exists(systemDPass() + serviceName() + ".service");
+        return QFileInfo::exists(systemDPath() + serviceName() + ".service");
     }
 
     auto &settings = getSettings(serviceName());
@@ -516,8 +516,8 @@ bool QtServiceBasePrivate::installSysD(const QString &account, const QString &pa
 
     settings.sync();
 
-    bool renamed = QFile(systemDPass() + controller.serviceName() + ".conf").rename(
-                systemDPass() + controller.serviceName() + ".service");
+    bool renamed = QFile(systemDPath() + controller.serviceName() + ".conf").rename(
+                systemDPath() + controller.serviceName() + ".service");
 
     QSettings::Status ret = settings.status();
     if (ret == QSettings::AccessError && renamed) {

--- a/qtservice/src/qtservice_win.cpp
+++ b/qtservice/src/qtservice_win.cpp
@@ -906,8 +906,8 @@ bool QtServiceBasePrivate::install(const QString &account, const QString &passwo
 
 QString QtServiceBasePrivate::filePath() const
 {
-    if (!serviceCustomPass.isEmpty())
-        return serviceCustomPass;
+    if (!serviceCustomPath.isEmpty())
+        return serviceCustomPath;
 
     wchar_t path[_MAX_PATH];
     ::GetModuleFileNameW( 0, path, sizeof(path) );
@@ -954,7 +954,7 @@ void QtServiceBase::setServiceFlags(QtServiceBase::ServiceFlags flags)
 
 void QtServiceBase::setServiceExecutable(const QString &exec)
 {
-    d_ptr->serviceCustomPass= exec;
+    d_ptr->serviceCustomPath= exec;
 }
 
 

--- a/qtservice/src/qtservice_win.cpp
+++ b/qtservice/src/qtservice_win.cpp
@@ -906,6 +906,9 @@ bool QtServiceBasePrivate::install(const QString &account, const QString &passwo
 
 QString QtServiceBasePrivate::filePath() const
 {
+    if (!serviceCustomPass.isEmpty())
+        return serviceCustomPass;
+
     wchar_t path[_MAX_PATH];
     ::GetModuleFileNameW( 0, path, sizeof(path) );
     return QString::fromUtf16((unsigned short*)path);
@@ -947,6 +950,11 @@ void QtServiceBase::setServiceFlags(QtServiceBase::ServiceFlags flags)
     d_ptr->serviceFlags = flags;
     if (d_ptr->sysd)
         d_ptr->sysd->setServiceFlags(flags);
+}
+
+void QtServiceBase::setServiceExecutable(const QString &exec)
+{
+    d_ptr->serviceCustomPass= exec;
 }
 
 


### PR DESCRIPTION
Current qt-service do not working with systemd system, this is PR fix this problem.

I also added the ability to manually set the path to the executable file of the service, since sometimes a service needs a shell that configures its environment.

* setServiceExecutable