### PR TITLE
Fixing Qt6 build error.

### DIFF
--- a/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/qtsingleapplication/src/qtlocalpeer.cpp
@@ -46,7 +46,11 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
     prefix.truncate(6);
 
     QByteArray idc = id.toUtf8();
+#if QT_VERSION < 0x060000
     quint16 idNum = qChecksum(idc.constData(), idc.size());
+#else
+    quint16 idNum = qChecksum(QByteArrayView(idc.constData(), idc.size()));
+#endif
     socketName = QLatin1String("qtsingleapp-") + prefix
                  + QLatin1Char('-') + QString::number(idNum, 16);
 


### PR DESCRIPTION
It builds failed when the macro 'QT_DISABLE_DEPRECATED_UP_TO' was set in the CMakeLists.txt :
`add_definitions(-DQT_DISABLE_DEPRECATED_UP_TO=0x060000)`

This PR will fix the issue.